### PR TITLE
Add tag workflow

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,61 @@
+# This workflow will be triggered by a GitHub release.
+# The workflow pulls the Docker image that was built on `main` from our private
+# registry and pushes an image to our public registry.
+---
+name: Tag release image
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEPLOY_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Tag image to Amazon ECR
+        env:
+          PRIVATE_IMAGE: "${{ steps.ecr.outputs.registry }}/proxy"
+          SOURCE_TAG: "main-${{ github.sha }}"
+          PUBLIC_IMAGE: "${{ steps.ecr.outputs.registry }}/proxy"
+          TAG: "release-${{ github.event.release.tag_name }}"
+        run: |
+          if docker pull "$PRIVATE_IMAGE:$SOURCE_TAG" ; then
+            docker tag "$PRIVATE_IMAGE:$SOURCE_TAG" "$PUBLIC_IMAGE:$TAG"
+            docker push "$PUBLIC_IMAGE:$TAG"
+          else
+            echo "::error::Image was not found, please wait until it is finished uploading"
+            exit 1
+          fi
+
+      - name: Publish to Docker Hub
+        env:
+          PRIVATE_IMAGE: "${{ steps.ecr.outputs.registry }}/proxy"
+          SOURCE_TAG: "main-${{ github.sha }}"
+          PUBLIC_IMAGE: "fiberplane/proxy"
+          TAG: "${{ github.event.release.tag_name }}"
+        run: |
+          if docker pull "$PRIVATE_IMAGE:$SOURCE_TAG" ; then
+            docker tag "$PRIVATE_IMAGE:$SOURCE_TAG" "$PUBLIC_IMAGE:$TAG"
+            docker push "$PUBLIC_IMAGE:$TAG"
+          else
+            echo "::error::Image was not found, please wait until it is finished uploading"
+            exit 1
+          fi


### PR DESCRIPTION
This will pull the Docker image from our private registry and then re-tag it,
and then push it to our private registry, as well as to our public Docker Hub
registry.

Resolves: FP-766
