### PR TITLE
Allow omission of PROVIDERS variable

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -19,7 +19,7 @@ all_providers = {
 # Run the data source providers
 data_sources_yaml = ''
 providers = []
-if not os.getenv('PROVIDERS') or os.getenv('PROVIDERS') == 'all':
+if not os.getenv('PROVIDERS').strip() or os.getenv('PROVIDERS') == 'all':
   providers = all_providers.keys()
 else:
   providers = os.getenv('PROVIDERS').split(',')


### PR DESCRIPTION
When the `PROVIDERS` environment variable isn't specified, it should be treated the same as "all", because without any providers it results in an empty config which is invalid.