### PR TITLE
Fix proxy in run on host mode

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -59,7 +59,7 @@ if 'elasticsearch' in providers:
     labels=['customer'])
 
 if run_proxy_on_host:
-  api_base = 'ws://localhost:3000'
+  api_base = 'ws://localhost:3030'
 else:
   api_base = 'ws://api'
 env={


### PR DESCRIPTION
if you run tilt with all services running on host, the proxy is erroring out because it can't reach relay (?). this change will fix routing - now everything works!