### PR TITLE
Add Cargo's config.toml file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[registry]
+default = "artifactory"
+
+[registries.artifactory]
+index = "https://fiberplane.jfrog.io/artifactory/git/internal-cargo-local.git"
+
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
This should allow security check to run again.