### PR TITLE
Compile with TLS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "fpd"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fpd"
-version = "2.7.1"
+version = "2.7.2"
 edition = "2018"
 description = "The Fiberplane Daemon enables secure communication between Fiberplane and your data sources using WebAssembly-based providers."
 authors = ["Fiberplane <info@fiberplane.com>"]
@@ -32,7 +32,7 @@ serde_yaml = "0.8.21"
 thiserror = "1.0.38"
 time = "0.3.14"
 tokio = { version = "1.10.1", features = ["full"] }
-tokio-tungstenite = "0.16"
+tokio-tungstenite = { version = "0.16", features = ["rustls-tls-native-roots"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
 url = "2.2.2"
@@ -46,7 +46,6 @@ test-log = { version = "0.2.11", default-features = false, features = [
     "trace",
 ] }
 tokio = { version = "1.10.1", features = ["full", "test-util"] }
-tokio-tungstenite = { version = "0.16", features = ["rustls-tls-native-roots"] }
 test-env-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 


### PR DESCRIPTION
# Description

Fixing this issue:

```console
% API_BASE=wss://dev.fiberplane.io RUST_LOG=error fpd --token foo --wasm-dir . | grep -i "catnip"

2023-02-14T11:37:32.071359Z ERROR fpd::tasks::service: error=URL error: TLS support not compiled in
2023-02-14T11:37:32.071458Z ERROR fpd: daemon encountered a error err=URL error: TLS support not compiled in

Caused by:
    TLS support not compiled in
Error: Daemon encountered an error: URL error: TLS support not compiled in

Caused by:
    TLS support not compiled in
```

For the record, I think I didn't have the issue in dev because I had the
additive feature of the dev-dependency of tokio-tungstenite for tests.
Therefore the fix here is to promote the feature from dev-only to
fully-fledged
