### PR TITLE
Stop holding SpanGuard across await points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "fpd"
-version = "2.7.2"
+version = "2.7.4"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fpd"
-version = "2.7.2"
+version = "2.7.4"
 edition = "2018"
 description = "The Fiberplane Daemon enables secure communication between Fiberplane and your data sources using WebAssembly-based providers."
 authors = ["Fiberplane <info@fiberplane.com>"]

--- a/deployment/deployment.template.yaml
+++ b/deployment/deployment.template.yaml
@@ -25,10 +25,7 @@ spec:
                   name: fpd-config
                   key: rust_log
             - name: LOG_JSON
-              valueFrom:
-                configMapKeyRef:
-                  name: fpd-config
-                  key: log_json
+              value: "true"
             - name: TOKEN
               valueFrom:
                 secretKeyRef:

--- a/deployment/deployment.template.yaml
+++ b/deployment/deployment.template.yaml
@@ -24,6 +24,11 @@ spec:
                 configMapKeyRef:
                   name: fpd-config
                   key: rust_log
+            - name: LOG_JSON
+              valueFrom:
+                configMapKeyRef:
+                  name: fpd-config
+                  key: log_json
             - name: TOKEN
               valueFrom:
                 secretKeyRef:

--- a/deployment/local/deployment.template.yaml
+++ b/deployment/local/deployment.template.yaml
@@ -20,7 +20,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: RUST_LOG
-              value: ${RUST_LOG-proxy=trace}
+              value: ${RUST_LOG-fpd=trace}
             - name: TOKEN
               value: ${TOKEN}
             - name: LISTEN_ADDRESS


### PR DESCRIPTION
This is meant to solve an issue with tracing messages running away with infinite `conn_id` nesting in spans