### PR TITLE
fix: log a connection error to prometheus as an error, not a warning

### DIFF
--- a/src/tasks/service.rs
+++ b/src/tasks/service.rs
@@ -652,7 +652,7 @@ impl ProxyService {
 
                 if let Some((delay, task)) = task.next() {
                     if response.is_err() {
-                        warn!(
+                        error!(
                             "error connecting to data source: {name}, retrying in {}s",
                             delay.as_secs()
                         );


### PR DESCRIPTION
While trying out fiberplane, I forgot to set the prometheus port in the configmap.
The visual feedback of an error would have helped me to debug this situation faster, hence I changed the log level to error.