### PR TITLE
fix: log a connection error to prometheus as an error, not a warning

### DIFF
--- a/src/tasks/service.rs
+++ b/src/tasks/service.rs
@@ -652,7 +652,7 @@ impl ProxyService {
 
                 if let Some((delay, task)) = task.next() {
                     if response.is_err() {
-                        warn!(
+                        error!(
                             "error connecting to data source: {name}, retrying in {}s",
                             delay.as_secs()
                         );


### PR DESCRIPTION
Recommit of approved #129 to bypass CI issues.

The original commit/authorship have been preserved.
