### PR TITLE
Limit Cargo to current thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "fpd"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use tokio::fs;
 use tracing::{error, info, trace, warn};
 use tracing_subscriber::EnvFilter;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), anyhow::Error> {
     let args = cli::Arguments::parse();
 


### PR DESCRIPTION
I know this is a cop-out, but it's a workaround to deal with [this issue](https://github.com/fiberplane/fp-bindgen/issues/194) in `fp-bindgen`. For a proper fix, we should prioritize https://github.com/fiberplane/fp-bindgen/issues/185.

Fixes FP-3272.