### PR TITLE
Pull providers in Tilt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /target
 deployment/local/data_sources.yaml
+providers

--- a/Tiltfile
+++ b/Tiltfile
@@ -69,6 +69,10 @@ if run_fpd_on_host:
   if os.getenv('OVERWRITE_DATA_SOURCES') != '0':
     local('echo %s > deployment/local/data_sources.yaml' % shlex.quote(data_sources_yaml))
 
+  # Make sure providers have been pulled at least once.
+  if not os.path.exists("providers"):
+    local('cargo run pull --wasm-dir=providers')
+
   local_resource('fpd',
     serve_env=env,
     serve_cmd='cargo run -- --wasm-dir providers',


### PR DESCRIPTION
If providers have never been pulled before, we need to pull them at least once, otherwise Tilt's `RUN_ON_HOST=all` will fail in a rather confusing manner.