### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-The format of this file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+The format of this file is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
 - TBD
+
+## [2.17.0]
+
+- Updated dependencies
 
 ## [2.15.0]
 
@@ -20,10 +25,9 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 
 - update providers and add Parseable provider (#144)
 
-
 ## [2.7.5]
 
 ### Changed
 
-- Remove support for legacy proxy messages. Currently it only supports version 2 (#128)
-
+- Remove support for legacy proxy messages. Currently it only supports version 2
+  (#128)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ test-env-log = { version = "0.2", default-features = false, features = [
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [patch.crates-io]
-fiberplane = { git = "ssh://git@github.com/fiberplane/fiberplane.git", branch = "main" }
+#fiberplane = { git = "ssh://git@github.com/fiberplane/fiberplane.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fpd"
-version = "2.17.0"
+version = "2.18.0"
 edition = "2018"
 description = "The Fiberplane Daemon enables secure communication between Fiberplane and your data sources using WebAssembly-based providers."
 authors = ["Fiberplane <info@fiberplane.com>"]


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated