### PR TITLE
Bump the version of fpd

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+- [ ] The Pull Request changes the version in Cargo.toml, following semver
+  + Bump the beta version if it's already there,
+  + Bump the patch version for a bugfix,
+  + Bump the minor version for a backwards-compatible feature addition
+  + Bump the major version for a breaking change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fpd"
-version = "2.18.0"
+version = "2.19.0"
 edition = "2018"
 description = "The Fiberplane Daemon enables secure communication between Fiberplane and your data sources using WebAssembly-based providers."
 authors = ["Fiberplane <info@fiberplane.com>"]


### PR DESCRIPTION
Our in-house release script expects PRs to modify the next version they target. Since 2.18.0 is already done, we should change that. Since I didn't follow the PRs, going for a conservative minor bump
