### PR TITLE
Use https for fiberplane dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "base64uuid"
 version = "1.1.0"
-source = "git+ssh://git@github.com/fiberplane/fiberplane.git?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
+source = "git+https://github.com/fiberplane/fiberplane?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
 dependencies = [
  "base64 0.13.1",
  "serde",
@@ -1112,7 +1112,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 [[package]]
 name = "fiberplane"
 version = "1.0.0-beta.14"
-source = "git+ssh://git@github.com/fiberplane/fiberplane.git?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
+source = "git+https://github.com/fiberplane/fiberplane?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
 dependencies = [
  "base64uuid",
  "fiberplane-models",
@@ -1123,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "fiberplane-models"
 version = "1.0.0-beta.13"
-source = "git+ssh://git@github.com/fiberplane/fiberplane.git?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
+source = "git+https://github.com/fiberplane/fiberplane?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
 dependencies = [
  "base64 0.13.1",
  "base64uuid",
@@ -1146,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "fiberplane-provider-bindings"
 version = "2.0.0-beta.13"
-source = "git+ssh://git@github.com/fiberplane/fiberplane.git?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
+source = "git+https://github.com/fiberplane/fiberplane?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
 dependencies = [
  "bytes",
  "fiberplane-models",
@@ -1162,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "fiberplane-provider-runtime"
 version = "2.0.0-beta.13"
-source = "git+ssh://git@github.com/fiberplane/fiberplane.git?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
+source = "git+https://github.com/fiberplane/fiberplane?branch=main#9bf3cb7b7cca1d6a6f68a369914f5a84439f43ce"
 dependencies = [
  "bytes",
  "fiberplane-models",
@@ -1657,7 +1657,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ test-env-log = { version = "0.2", default-features = false, features = [
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [patch.crates-io]
-fiberplane = { git = "ssh://git@github.com/fiberplane/fiberplane.git", branch = "main" }
+fiberplane = { git = "https://github.com/fiberplane/fiberplane", branch = "main" }


### PR DESCRIPTION
- [x] The Pull Request changes the version in Cargo.toml, following semver
  + Bump the beta version if it's already there,
  + Bump the patch version for a bugfix,
  + Bump the minor version for a backwards-compatible feature addition
  + Bump the major version for a breaking change
